### PR TITLE
UDF argument type matching

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -1099,7 +1099,8 @@ public class CalciteSqlParser {
     }
     String functionName = function.getOperator();
     if (compilable) {
-      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numOperands);
+      String[] paramClassName = getParamClassNameArray(operands);
+      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, paramClassName);
       if (functionInfo != null) {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {
@@ -1132,5 +1133,13 @@ public class CalciteSqlParser {
       return false;
     }
     return false;
+  }
+
+  private static String[] getParamClassNameArray(List<Expression> operands) {
+    String[] paramClassName = new String[operands.size()];
+    for (int i = 0; i < operands.size(); i++) {
+      paramClassName[i] = operands.get(i).getClass().getSimpleName();
+    }
+    return paramClassName;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -193,10 +193,11 @@ public class TransformFunctionFactory {
           }
         } else {
           // Scalar function
-          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+          String[] paramClassName = getParamClassNameArray(arguments);
+          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, paramClassName);
           if (functionInfo == null) {
             throw new BadQueryRequestException(
-                String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
+                String.format("Unsupported function: %s with %d parameters: %s", functionName, numArguments, FunctionRegistry.getSortedParamClassNameString(paramClassName)));
           }
           transformFunction = new ScalarTransformFunctionWrapper(functionInfo);
         }
@@ -224,5 +225,13 @@ public class TransformFunctionFactory {
 
   private static String canonicalize(String functionName) {
     return StringUtils.remove(functionName, '_').toLowerCase();
+  }
+
+  private static String[] getParamClassNameArray(List<ExpressionContext> arguments) {
+    String[] paramClassName = new String[arguments.size()];
+    for (int i = 0; i < arguments.size(); i++) {
+      paramClassName[i] = arguments.get(i).getClass().getSimpleName();
+    }
+    return paramClassName;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -37,9 +37,10 @@ public class PostAggregationFunction {
 
   public PostAggregationFunction(String functionName, ColumnDataType[] argumentTypes) {
     int numArguments = argumentTypes.length;
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+    String[] paramClassName = getParamClassNameArray(argumentTypes);
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, paramClassName);
     Preconditions
-        .checkArgument(functionInfo != null, "Unsupported function: %s with %s parameters", functionName, numArguments);
+        .checkArgument(functionInfo != null, "Unsupported function: %s with %s parameters: %s", functionName, numArguments, FunctionRegistry.getSortedParamClassNameString(paramClassName));
     _functionInvoker = new FunctionInvoker(functionInfo);
     Class<?>[] parameterClasses = _functionInvoker.getParameterClasses();
     PinotDataType[] parameterTypes = _functionInvoker.getParameterTypes();
@@ -83,5 +84,13 @@ public class PostAggregationFunction {
     }
     Object result = _functionInvoker.invoke(arguments);
     return _resultType == ColumnDataType.STRING ? result.toString() : result;
+  }
+
+  private String[] getParamClassNameArray(ColumnDataType[] argumentTypes) {
+    String[] paramClassName = new String[argumentTypes.length];
+    for (int i = 0; i < argumentTypes.length; i++) {
+      paramClassName[i] = argumentTypes[i].getClass().getSimpleName();
+    }
+    return paramClassName;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -68,13 +68,22 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
           childNodes[i] = planExecution(arguments.get(i));
         }
         String functionName = function.getFunctionName();
-        FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
-        Preconditions.checkState(functionInfo != null, "Unsupported function: %s with %s parameters", functionName,
-            numArguments);
+        String[] paramClassName = getParamClassNameArray(arguments);
+        FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, paramClassName);
+        Preconditions.checkState(functionInfo != null, "Unsupported function: %s with %s parameters: %s", functionName,
+            numArguments, FunctionRegistry.getSortedParamClassNameString(paramClassName));
         return new FunctionExecutionNode(functionInfo, childNodes);
       default:
         throw new IllegalStateException();
     }
+  }
+
+  private String[] getParamClassNameArray(List<ExpressionContext> arguments) {
+    String[] paramClassName = new String[arguments.size()];
+    for (int i = 0; i < arguments.size(); i++) {
+      paramClassName[i] = arguments.get(i).getClass().getSimpleName();
+    }
+    return paramClassName;
   }
 
   @Override


### PR DESCRIPTION
UDF argument type matching

## Description
Currently, ScalarFunction are registered based on the function name and the number of arguments. 
This PR adds the support to register multiple functions with same name and number of arguments but different argument types.
Related issue: https://github.com/apache/pinot/issues/6955

## Changes
* Add helper functions: getParamClassNameArray and getSortedParamClassNameString in FunctionRegistery
*  Modify registerFunction in FunctionRegistery to register a function based on function name, number of parameters and parameter types
* Modify getFunctionInfo in FunctionRegistery to compute FunctionInfo based on function name, number of parameters and parameter types
* Add helper function: getParamClassNameArray in FunctionRegistery callers to get the array of parameter class name
